### PR TITLE
Milestone 3.2: State Migration - Cleanup

### DIFF
--- a/docs/developer-guide/changelog.md
+++ b/docs/developer-guide/changelog.md
@@ -15,11 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Table of Contents
 
-1. [Version 0.4.4 (Current)](#version-044---2025-11-27)
-2. [Version 0.4.3](#version-043---2025-11-24)
-3. [Version 0.4.2](#version-042---2025-11-24)
-4. [Version 0.4.1](#version-041---2025-11-24)
-5. [Version 0.4.0](#version-040---2025-11-11)
+1. [Version 0.4.5 (Current)](#version-045---2025-11-27)
+2. [Version 0.4.4](#version-044---2025-11-27)
+3. [Version 0.4.3](#version-043---2025-11-24)
+4. [Version 0.4.2](#version-042---2025-11-24)
+5. [Version 0.4.1](#version-041---2025-11-24)
+6. [Version 0.4.0](#version-040---2025-11-11)
 6. [Version 0.3.2](#version-032---2025-10-20)
 7. [Version 0.3.1](#version-031---2025-10-20)
 8. [Version 0.3.0](#version-030---2025-10-20)
@@ -36,9 +37,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.4.4] - 2025-11-27
+## [0.4.5] - 2025-11-27
 
 **Current Release**
+
+### Changed
+
+✅ **State Migration - Cleanup (Milestone 3.2)**
+- **Removed global variables from handlers.py (Task 3.2.1):**
+  - Deleted `_ACTIVE_CONTEXT` global variable
+  - Deleted `_CURRENT_STAGE` global variable
+  - Deleted `_TOOL_USAGE_STATS` global variable
+  - Deleted deprecated `_track_tool_usage()` function
+  - Replaced global fallbacks with default values ("baseline", "setup", {})
+  - Grep for global variables returns 0 results
+
+### Added
+
+✅ **Concurrent Session Isolation Verification (Task 3.2.2)**
+- `test_concurrent_sessions_independent_state()`: Verifies 2 concurrent sessions have completely independent state across all 4 state components
+- `test_workflow_switch_preserves_focused_database()`: Verifies focused database remains stable during workflow/stage switches
+- 100% code coverage for session_state.py
+- All 344 tests pass
+
+### Technical Details
+
+- SessionState now the single source of truth for per-session state
+- No global variable fallback means handlers require session context for state persistence
+- Tests updated to provide session context where state persistence is needed
+- Phase 3 complete: Multi-tenancy foundation fully established
+
+### Files Changed
+
+**Modified:**
+- `mcp_arangodb_async/handlers.py` - Remove global variables and fallbacks
+- `tests/test_handlers_unit.py` - 3 tests updated to use session state
+- `tests/test_mcp_integration.py` - 4 tests updated to include session_state in mock context
+- `tests/test_session_state_unit.py` - 2 new verification tests
+
+### Related Issues
+
+Closes [#13](https://github.com/LittleCoinCoin/mcp-arangodb-async/issues/13), [#14](https://github.com/LittleCoinCoin/mcp-arangodb-async/issues/14)
+
+---
+
+## [0.4.4] - 2025-11-27
 
 ### Changed
 

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -604,8 +604,15 @@ class TestMCPDesignPatternToolsIntegration:
     @pytest.mark.asyncio
     async def test_get_active_workflow(self):
         """Test arango_get_active_workflow through MCP server."""
+        from mcp_arangodb_async.session_state import SessionState
+
+        session_state = SessionState()
         with patch.object(server, 'request_context') as mock_ctx:
-            mock_ctx.lifespan_context = {"db": self.mock_db, "client": self.mock_client}
+            mock_ctx.lifespan_context = {
+                "db": self.mock_db,
+                "client": self.mock_client,
+                "session_state": session_state
+            }
 
             # First switch to a known context
             await server._handlers["call_tool"](
@@ -631,8 +638,15 @@ class TestMCPDesignPatternToolsIntegration:
     @pytest.mark.asyncio
     async def test_workflow_switching_workflow(self):
         """Test complete workflow switching workflow."""
+        from mcp_arangodb_async.session_state import SessionState
+
+        session_state = SessionState()
         with patch.object(server, 'request_context') as mock_ctx:
-            mock_ctx.lifespan_context = {"db": self.mock_db, "client": self.mock_client}
+            mock_ctx.lifespan_context = {
+                "db": self.mock_db,
+                "client": self.mock_client,
+                "session_state": session_state
+            }
 
             # Switch to data_analysis
             result1 = await server._handlers["call_tool"](
@@ -706,8 +720,15 @@ class TestMCPDesignPatternToolsIntegration:
     @pytest.mark.asyncio
     async def test_workflow_stage_progression(self):
         """Test complete workflow stage progression."""
+        from mcp_arangodb_async.session_state import SessionState
+
+        session_state = SessionState()
         with patch.object(server, 'request_context') as mock_ctx:
-            mock_ctx.lifespan_context = {"db": self.mock_db, "client": self.mock_client}
+            mock_ctx.lifespan_context = {
+                "db": self.mock_db,
+                "client": self.mock_client,
+                "session_state": session_state
+            }
 
             # Reset to setup stage
             await server._handlers["call_tool"](
@@ -793,8 +814,15 @@ class TestMCPDesignPatternToolsIntegration:
     @pytest.mark.asyncio
     async def test_complete_mcp_design_pattern_workflow(self):
         """Test realistic workflow combining all three patterns."""
+        from mcp_arangodb_async.session_state import SessionState
+
+        session_state = SessionState()
         with patch.object(server, 'request_context') as mock_ctx:
-            mock_ctx.lifespan_context = {"db": self.mock_db, "client": self.mock_client}
+            mock_ctx.lifespan_context = {
+                "db": self.mock_db,
+                "client": self.mock_client,
+                "session_state": session_state
+            }
 
             # Step 1: Search for tools (Pattern 1)
             search_result = await server._handlers["call_tool"](

--- a/tests/test_session_state_unit.py
+++ b/tests/test_session_state_unit.py
@@ -144,20 +144,142 @@ class TestSessionState:
         """Test async lock safety with concurrent access."""
         session_id = "test_session_1"
         self.session_state.initialize_session(session_id)
-        
+
         # Simulate concurrent writes
         async def set_database(db_name: str):
             await self.session_state.set_focused_database(session_id, db_name)
             await asyncio.sleep(0.01)  # Simulate some work
-        
+
         # Run concurrent operations
         await asyncio.gather(
             set_database("db1"),
             set_database("db2"),
             set_database("db3")
         )
-        
+
         # Should have one of the values (last write wins)
         result = self.session_state.get_focused_database(session_id)
         assert result in ["db1", "db2", "db3"]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_sessions_independent_state(self):
+        """Test that concurrent sessions have completely independent state.
+
+        Milestone 3.2 verification: Ensures session isolation across all state
+        components (focused_database, active_workflow, tool_lifecycle_stage,
+        tool_usage_stats) under simulated concurrent access.
+        """
+        session_1 = "agent_1_session"
+        session_2 = "agent_2_session"
+
+        # Initialize both sessions
+        self.session_state.initialize_session(session_1)
+        self.session_state.initialize_session(session_2)
+
+        # Simulate concurrent operations from two agents
+        async def agent_1_workflow():
+            """Agent 1: Production database, data_migration workflow."""
+            await self.session_state.set_focused_database(session_1, "production")
+            await self.session_state.set_active_workflow(session_1, "data_migration")
+            await self.session_state.set_tool_lifecycle_stage(session_1, "data_loading")
+            self.session_state.track_tool_usage(session_1, "arango_query")
+            self.session_state.track_tool_usage(session_1, "arango_query")  # Use twice
+            self.session_state.track_tool_usage(session_1, "arango_insert")
+            await asyncio.sleep(0.01)  # Simulate work
+
+        async def agent_2_workflow():
+            """Agent 2: Staging database, analytics workflow."""
+            await self.session_state.set_focused_database(session_2, "staging")
+            await self.session_state.set_active_workflow(session_2, "analytics")
+            await self.session_state.set_tool_lifecycle_stage(session_2, "analysis")
+            self.session_state.track_tool_usage(session_2, "arango_traverse")
+            self.session_state.track_tool_usage(session_2, "arango_graph_stats")
+            await asyncio.sleep(0.01)  # Simulate work
+
+        # Run both agents concurrently
+        await asyncio.gather(agent_1_workflow(), agent_2_workflow())
+
+        # Verify complete isolation - focused database
+        assert self.session_state.get_focused_database(session_1) == "production"
+        assert self.session_state.get_focused_database(session_2) == "staging"
+
+        # Verify complete isolation - active workflow
+        assert self.session_state.get_active_workflow(session_1) == "data_migration"
+        assert self.session_state.get_active_workflow(session_2) == "analytics"
+
+        # Verify complete isolation - tool lifecycle stage
+        assert self.session_state.get_tool_lifecycle_stage(session_1) == "data_loading"
+        assert self.session_state.get_tool_lifecycle_stage(session_2) == "analysis"
+
+        # Verify complete isolation - tool usage stats
+        stats_1 = self.session_state.get_tool_usage_stats(session_1)
+        stats_2 = self.session_state.get_tool_usage_stats(session_2)
+
+        # Session 1 should have arango_query and arango_insert
+        assert "arango_query" in stats_1
+        assert "arango_insert" in stats_1
+        assert "arango_traverse" not in stats_1
+        assert stats_1["arango_query"]["use_count"] == 2
+        assert stats_1["arango_insert"]["use_count"] == 1
+
+        # Session 2 should have arango_traverse and arango_graph_stats
+        assert "arango_traverse" in stats_2
+        assert "arango_graph_stats" in stats_2
+        assert "arango_query" not in stats_2
+
+        # Verify cleanup is isolated
+        self.session_state.cleanup_session(session_1)
+
+        # Session 1 should be cleaned up
+        assert not self.session_state.has_session(session_1)
+
+        # Session 2 should still be intact
+        assert self.session_state.has_session(session_2)
+        assert self.session_state.get_focused_database(session_2) == "staging"
+        assert self.session_state.get_active_workflow(session_2) == "analytics"
+
+    @pytest.mark.asyncio
+    async def test_workflow_switch_preserves_focused_database(self):
+        """Test that switching workflow does not affect focused database.
+
+        Milestone 3.2 verification: Ensures the focused database context
+        remains stable when agents switch between workflows, preventing
+        the architectural risk identified in Integration Design v3.
+        """
+        session_id = "test_session"
+
+        self.session_state.initialize_session(session_id)
+
+        # Set focused database
+        await self.session_state.set_focused_database(session_id, "customer_db")
+        assert self.session_state.get_focused_database(session_id) == "customer_db"
+
+        # Switch through multiple workflows
+        workflows = ["baseline", "data_analysis", "graph_modeling", "bulk_operations"]
+
+        for workflow in workflows:
+            await self.session_state.set_active_workflow(session_id, workflow)
+
+            # Verify workflow changed
+            assert self.session_state.get_active_workflow(session_id) == workflow
+
+            # Verify focused database preserved
+            assert self.session_state.get_focused_database(session_id) == "customer_db"
+
+        # Also verify tool lifecycle stage changes don't affect focused database
+        stages = ["setup", "data_loading", "analysis", "cleanup"]
+
+        for stage in stages:
+            await self.session_state.set_tool_lifecycle_stage(session_id, stage)
+
+            # Verify stage changed
+            assert self.session_state.get_tool_lifecycle_stage(session_id) == stage
+
+            # Verify focused database preserved
+            assert self.session_state.get_focused_database(session_id) == "customer_db"
+
+        # Final verification
+        assert self.session_state.get_focused_database(session_id) == "customer_db"
+        assert self.session_state.get_active_workflow(session_id) == "bulk_operations"
+        assert self.session_state.get_tool_lifecycle_stage(session_id) == "cleanup"
 


### PR DESCRIPTION
## Summary

Remove global variables and verify concurrent session isolation, completing Phase 3 (State Migration) of the multi-tenancy implementation.

## Tasks Completed

### Task 3.2.1: Global Variable Removal (Issue #13)
- Deleted `_ACTIVE_CONTEXT` global variable from handlers.py
- Deleted `_CURRENT_STAGE` global variable from handlers.py
- Deleted `_TOOL_USAGE_STATS` global variable from handlers.py
- Deleted deprecated `_track_tool_usage()` function
- Removed all `global` statements from handlers
- Replaced global fallbacks with default values ("baseline", "setup", {})
- Grep for global variables returns 0 results

### Task 3.2.2: Verification (Issue #14)
- Added `test_concurrent_sessions_independent_state()` test
- Added `test_workflow_switch_preserves_focused_database()` test
- 100% code coverage for session_state.py
- All 344 tests pass

## Technical Details

- SessionState is now the single source of truth for per-session state
- No global variable fallback means handlers require session context for state persistence
- Tests updated to provide session context where state persistence is needed
- Phase 3 complete: Multi-tenancy foundation fully established

## Files Changed

- `mcp_arangodb_async/handlers.py` - Remove global variables and fallbacks
- `tests/test_handlers_unit.py` - 3 tests updated to use session state
- `tests/test_mcp_integration.py` - 4 tests updated to include session_state in mock context
- `tests/test_session_state_unit.py` - 2 new verification tests
- `docs/developer-guide/changelog.md` - Version 0.4.5 changelog entry

## Success Criteria Met

✅ All tasks completed with success gates met
✅ All unit tests pass (100% coverage for session_state.py)
✅ Global variables completely removed (grep returns 0 results)
✅ Concurrent session isolation verified
✅ Ready to proceed to Phase 4: Tool Implementation

## Related Issues

Closes #13, Closes #14

## Milestone

https://github.com/LittleCoinCoin/mcp-arangodb-async/milestone/5

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author